### PR TITLE
Fix Nginx configuration to listen on port 5000

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,7 @@ RUN npm run build
 
 
 FROM nginx:1.19.10 as prod
-EXPOSE 80
+EXPOSE 5000
+ENV PORT=5000
+COPY --from=build /app/config/nginx/templates /etc/nginx/templates
 COPY --from=build /app/build /usr/share/nginx/html

--- a/config/nginx/templates/default.conf.template
+++ b/config/nginx/templates/default.conf.template
@@ -1,0 +1,14 @@
+server {
+    listen       ${PORT};
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
The default port for Nginx is 80. Elastic Beanstalk needs the server to be listening on port 5000. This pull request overrides the default Nginx configuration file.